### PR TITLE
Fix buffer overflows

### DIFF
--- a/src/image.cc
+++ b/src/image.cc
@@ -159,15 +159,18 @@ int image_get_filename(image_ctx_t *ctx, char *out, size_t len_out, char *in){
 
 	if(len_src > len_ext && strcmp(in+len_src-len_ext,ctx->extension) == 0){
 		/* Already has correct extension and fits in buffer */
-		if(len_src < len_out)
-			strncpy(in,out,len_out);
+		if(len_src < len_out){
+			strncpy(out, in, len_out);
+			out[len_out-1] = '\0';
+		}
 		else
 			success = ENOMEM;
 	}else if(len_src > len_ext){
 		/* Doesn't have correct extension and fits */
 		if(len_src + len_ext < len_out){
 			strncpy(out,in,len_out);
-			strncat(out,ctx->extension,len_out);
+			out[len_out-1] = '\0';
+			strncat(out, ctx->extension, len_out - strlen(out) - 1);
 		}else
 			success = ENOMEM;
 	}else{


### PR DESCRIPTION
* Happens when using the -ant parameter

Error example:
signalserver -sdf data/SRTM3 -lat 47.7962 -lon 3.57028 -R 5 -txh 1.5 -rxh 1.5 -rt -130 -ant antenna/SC466 -color palette.dcf -f 868 -pm 1 -erp 0.282 -m -dbm -dbg -o exercice4 [2025-09-12 15:43:33.884] [info]
[2025-09-12 15:43:33.884] [info] Version 4.0 (master defdc59)
[2025-09-12 15:43:33.884] [info]     Compile date: Sep 12 2025 13:40:58
[2025-09-12 15:43:33.884] [info]     Built for 100 DEM tiles at 1200 pixels
[2025-09-12 15:43:33.884] [info]
*** buffer overflow detected ***: terminated
Abandon (core dumped)